### PR TITLE
Correct syntax error in order to run javascript specs with Jasmine

### DIFF
--- a/app/assets/javascripts/hyrax/file_manager/member.es6
+++ b/app/assets/javascripts/hyrax/file_manager/member.es6
@@ -62,7 +62,7 @@ export class FileManagerMember {
 
   track_hint() {
     new InputTracker(this.element.find("[data-member-link^=file_set_viewing_hint]"), this)
-    $("*[name^=file_set_viewing_hint").change(function() {
+    $('*[name^="file_set_viewing_hint"]').change(function() {
       let name = $(this).attr('name')
       let val = $("*[name=" + name + "]:checked").val()
       $("[data-member-link=" + name + "]" ).val(val)


### PR DESCRIPTION
Story: https://bugs.dlib.indiana.edu/browse/ESSI-424

Able to run Jasmine from the browser and from the terminal. There are currently 3 failing JS specs. 
![Screen Shot 2019-08-21 at 11 45 18 AM](https://user-images.githubusercontent.com/10081604/63459632-bd3aae00-c409-11e9-87b2-c8e606213678.png)
