### PR TITLE
restrict m3 profile to admins only

### DIFF
--- a/app/controllers/hyrax/my/m3_profiles_controller.rb
+++ b/app/controllers/hyrax/my/m3_profiles_controller.rb
@@ -1,6 +1,10 @@
 module Hyrax
   module My
     class M3ProfilesController < Hyrax::MyController
+      before_action do
+        authorize! :manage, M3Profile
+      end
+
       def index
         add_breadcrumb t(:'hyrax.controls.home'), root_path
         add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,7 +2,7 @@ class Ability
   include Hydra::Ability
 
   include Hyrax::Ability
-  self.ability_logic += [:everyone_can_create_curation_concerns]
+  self.ability_logic += [:everyone_can_create_curation_concerns, :m3_profile_abilities]
   # Define any customized permissions here.
   def custom_permissions
     can %i[file_manager save_structure structure], PagedResource
@@ -19,6 +19,12 @@ class Ability
     # end
     if current_user.admin?
         can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
+    end
+  end
+
+  def m3_profile_abilities
+    if current_user.admin?
+      can :manage, M3Profile
     end
   end
 

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -10,7 +10,9 @@
     <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
   <% end %>
 
-  <%= menu.nav_link(hyrax.my_m3_profiles_path,
-                    also_active_for: hyrax.dashboard_m3_profiles_path) do %>
-    <span class="fa fa-table" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.m3_profiles') %></span>
+  <% if can? :manage, M3Profile %>
+    <%= menu.nav_link(hyrax.my_m3_profiles_path,
+                      also_active_for: hyrax.dashboard_m3_profiles_path) do %>
+      <span class="fa fa-table" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.m3_profiles') %></span>
+    <% end %>
   <% end %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,36 +5,36 @@ FactoryBot.modify do
     sequence(:email) { |n| "email-#{srand}@test.com" }
     provider { 'cas' }
 
-    factory :admin do
+    trait :admin do
       roles { [Role.where(name: 'admin').first_or_create] }
     end
 
-    factory :authorized_patron do
+    trait :authorized_patron do
       # All CAS users are authorized patrons.
     end
 
-    factory :image_editor do
+    trait :image_editor do
       roles { [Role.where(name: 'image_editor').first_or_create] }
     end
 
-    factory :editor do
+    trait :editor do
       roles { [Role.where(name: 'editor').first_or_create] }
     end
 
-    factory :fulfiller do
+    trait :fulfiller do
       roles { [Role.where(name: 'fulfiller').first_or_create] }
     end
 
-    factory :curator do
+    trait :curator do
       roles { [Role.where(name: 'curator').first_or_create] }
     end
 
-    factory :complete_reviewer do
+    trait :complete_reviewer do
       email { 'complete@example.com' }
       roles { [Role.where(name: 'notify_complete').first_or_create] }
     end
 
-    factory :takedown_reviewer do
+    trait :takedown_reviewer do
       email { 'takedown@example.com' }
       roles { [Role.where(name: 'notify_takedown').first_or_create] }
     end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Ability do
-  let(:user) { FactoryBot.create :user }
+  let(:user) { create :user }
   let(:options) { {} }
   let(:ability) { described_class.new(user, options) }
   let(:authorized_groups) { ['Test group'] }
@@ -17,7 +17,7 @@ RSpec.describe Ability do
         end
       end
       context 'when a user is not persisted' do
-        let(:user) { FactoryBot.build :user }
+        let(:user) { build :user }
         it 'considers the user unregistered' do
           expect(ability.user_groups).not_to include('registered')
         end
@@ -55,19 +55,18 @@ RSpec.describe Ability do
   end
 
   describe '#m3_profile_abilities' do
-    let(:m3_profile) { FactoryBot.create :m3_profile }
-
-    before { ability = Ability.new(user) }
+    let(:m3_profile) { create :m3_profile }
 
     context 'when not admin' do
-      it "should not be manageable by a user of the buyer" do
+      it "should not be manageable" do
         expect(ability.can?(:manage, m3_profile)).to be_falsey
       end
     end
 
     context 'when admin' do
-      it "should be manageable by a user of the buyer" do
-        user.roles << Role.where(name: 'admin').first_or_create
+      let(:user) { create :user, :admin }
+
+      it "should be manageable" do
         expect(ability.can?(:manage, m3_profile)).to be_truthy
       end
     end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -53,4 +53,23 @@ RSpec.describe Ability do
       end
     end
   end
+
+  describe '#m3_profile_abilities' do
+    let(:m3_profile) { FactoryBot.create :m3_profile }
+
+    before { ability = Ability.new(user) }
+
+    context 'when not admin' do
+      it "should not be manageable by a user of the buyer" do
+        expect(ability.can?(:manage, m3_profile)).to be_falsey
+      end
+    end
+
+    context 'when admin' do
+      it "should be manageable by a user of the buyer" do
+        user.roles << Role.where(name: 'admin').first_or_create
+        expect(ability.can?(:manage, m3_profile)).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe Ability do
   describe '#m3_profile_abilities' do
     let(:m3_profile) { create :m3_profile }
 
-    context 'when not admin' do
+    context 'when the user is not an admin' do
       it "should not be manageable" do
         expect(ability.can?(:manage, m3_profile)).to be_falsey
       end
     end
 
-    context 'when admin' do
+    context 'when the user is an admin' do
       let(:user) { create :user, :admin }
 
       it "should be manageable" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,6 +82,7 @@ Capybara.default_driver = :rack_test # This is a faster driver
 Capybara.javascript_driver = :selenium_chrome_headless_sandboxless # This is slower
 
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
   let(:manage_feature) { false }
   let(:manage_workflow) { false }
   let(:manage_collection_types) { false }
+  let(:manage_m3_profiles) { false }
 
   before do
     allow_any_instance_of(User).to receive(:user_key).and_return('mjg')
@@ -24,6 +25,7 @@ RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
     allow(view).to receive(:can?).with(:manage, Hyrax::Feature).and_return(manage_feature)
     allow(view).to receive(:can?).with(:manage, Sipity::WorkflowResponsibility).and_return(manage_workflow)
     allow(view).to receive(:can?).with(:manage, :collection_types).and_return(manage_collection_types)
+    allow(view).to receive(:can?).with(:manage, M3Profile).and_return(manage_m3_profiles)
   end
 
   context 'with any user' do
@@ -38,7 +40,6 @@ RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
     it { is_expected.to have_link t('hyrax.admin.sidebar.transfers') }
     it { is_expected.to have_link t('hyrax.admin.sidebar.collections') }
     it { is_expected.to have_link t('hyrax.admin.sidebar.works') }
-    it { is_expected.to have_link t('hyrax.admin.sidebar.m3_profiles') }
   end
 
   context 'with a user who can read the admin dash' do
@@ -110,6 +111,15 @@ RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
 
     it { is_expected.to have_content t('hyrax.admin.sidebar.configuration') }
     it { is_expected.to have_link t('hyrax.admin.sidebar.collection_types') }
+  end
+
+  context 'with a user who can manage m3 profiles (flexible metadata)' do
+    let(:manage_m3_profiles) { true }
+
+    before { render }
+    subject { rendered }
+
+    it { is_expected.to have_content t('hyrax.admin.sidebar.m3_profiles') }
   end
 
   context 'when proxy deposits are enabled' do


### PR DESCRIPTION
@geekscruff Having a bit of trouble being able to easily utilize the user factory to create an admin in my specs. I have a workaround but feel that I shouldn't have to do it this way: https://notch8.slack.com/archives/CKY104K46/p1568418527000400