### PR TITLE
Fix ActiveRecord::SubclassNotFound error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ fits.log
 .secrets.sh
 /secrets
 .env.*
+
+# Ignore Universal Viewer && yarn dependencies
+public/uv/*
+yarn.lock

--- a/db/migrate/20190906004146_create_m3_profiles.rb
+++ b/db/migrate/20190906004146_create_m3_profiles.rb
@@ -3,12 +3,12 @@ class CreateM3Profiles < ActiveRecord::Migration[5.1]
     create_table :m3_profiles do |t|
       t.string :name
       t.integer :profile_version # version in m3
-      t.text :profile
       t.string :m3_version
       t.string :responsibility
       t.string :responsibility_statement
       t.string :date_modified
-      t.string :type
+      t.string :profile_type
+      t.text :profile
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -227,12 +227,12 @@ ActiveRecord::Schema.define(version: 20190926002320) do
   create_table "m3_profiles", force: :cascade do |t|
     t.string "name"
     t.integer "profile_version"
-    t.text "profile"
     t.string "m3_version"
     t.string "responsibility"
     t.string "responsibility_statement"
     t.string "date_modified"
-    t.string "type"
+    t.string "profile_type"
+    t.text "profile"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
Rename 'type' column on M3Profile table to avoid `ActiveRecord::SubclassNotFound` error 

Error: 
```
ActiveRecord::SubclassNotFound (The single-table inheritance mechanism failed to locate the subclass: 'concept'. This error is raised because the column 'type' is reserved for storing the class in case of inheritance. Please rename this column if you didn't intend it to be used for storing the inheritance class or overwrite M3Profile.inheritance_column to use another column for that information.)
```

Solution taken from: https://stackoverflow.com/a/12903705 

**If we really wanted to keep the column name `type` we could rename the `M3Profile.inheritance_column`, but I don't know if that could cause issues later on.** 